### PR TITLE
Add license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+Copyright (c) 2023—present ZM and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+dom-inline-style-filter incorporates dom-inline-style-filter, Copyright (c) 2018-present by 1904labs and contributors, https://github.com/1904labs/dom-to-image-more/graphs/contributors. dom-to-image-more is distributed under the terms of the MIT License.
+
+dom-inline-style-filter incorporates the work of Joseph White in the default style getter, Copyright (c) 1904labs, https://github.com/1904labs/dom-to-image-more/pull/71. This work is distributed under the terms of the MIT License.


### PR DESCRIPTION
### What changes have you made?
Add MIT license for compatibility with research targets.
Credit default style getter to `dom-to-image-more`.

### Anything else worth mentioning?
Also credits specific contributors.